### PR TITLE
Repair background texture style

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -283,7 +283,7 @@ table {
     width: 100%
 }
 
-table thead tr {
+thead {
     background: url(bg-th.gif);
     color: #f0f0f0;
 }


### PR DESCRIPTION
Before, the texture would only apply to certain parts of the table head, which would lead to some of the text hanging over the textured area and giving a disappointing appearance. 

![image](https://user-images.githubusercontent.com/17814535/61190711-42da7980-a666-11e9-99c3-8ca6914557be.png)

What I did was take the style that was being used and apply it top the entire table head, not just certain parts, so now all the text is clearly visible and has a uniform background style.

![image](https://user-images.githubusercontent.com/17814535/61190686-145c9e80-a666-11e9-9b16-20b9ad914241.png)
